### PR TITLE
chore(version): symfony packages below 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     "require": {
         "php": "^8.1",
         "facebook/graph-sdk": "^5.0",
-        "symfony/css-selector": "^5.3"
+        "symfony/css-selector": "^4.4 || ^5.3"
     },
     "require-dev": {
         "fakerphp/faker": "^1.16",
         "phpunit/phpunit": "^9.5",
         "phpdocumentor/reflection-docblock": "^5.3",
-        "symfony/yaml": "5.3.*",
+        "symfony/yaml": "4.4.* || 5.3.*",
         "squizlabs/php_codesniffer": "^3.0.0"
     },
     "autoload": {


### PR DESCRIPTION
Update Symfony packages versions, on some applications we are still restricted to an older version of Symfony, and get this error messages:
`Only one of these can be installed: symfony/css-selector[v5.3.0, ..., v5.4.21], symfony/symfony[v4.4.50]. symfony/symfony replaces symfony/css-selector and thus cannot coexist with it.`